### PR TITLE
now looks at all the drm lines and picks the best by default

### DIFF
--- a/smtty
+++ b/smtty
@@ -220,9 +220,22 @@ choose_drm_output() {
     short=${dir##*/}
     short=${short#card*-}
 
-    if ! read -r native_line <"$modes_path"; then
-      native_line="unknown"
-    fi
+    # Read all modes and pick the largest WxH by area
+    native_line="unknown"
+    local max_area=0
+    local mline mw mh area
+    while IFS= read -r mline; do
+      [[ -z "$mline" ]] && continue
+      if [[ "$mline" =~ ([0-9]+)x([0-9]+) ]]; then
+        mw=${BASH_REMATCH[1]}
+        mh=${BASH_REMATCH[2]}
+        area=$(( mw * mh ))
+        if (( area > max_area )); then
+          max_area=$area
+          native_line="$mline"
+        fi
+      fi
+    done <"$modes_path"
 
     entries+=("$short:$native_line")
     printf '  [%d] %s (native: %s)\n' "$idx" "$short" "$native_line"


### PR DESCRIPTION
fix: reads all lines of resolution modes, and picks highest area by default.
reason: I believe this to be a hyprland issue, things like hyprctl monitors do not have ordering on the resulution outputs, in my case i have a 5120x1440 monitor, but the first resulution and targeted by default was 3840x1080