### PR TITLE
Add self-updating functionality with smtty-update command

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -10,6 +10,7 @@ set -euo pipefail
 PREFIX=${PREFIX:-"$HOME/.local"}
 BINDIR="$PREFIX/bin"
 TARGET="$BINDIR/smtty"
+UPDATER_TARGET="$BINDIR/smtty-update"
 
 # Resolve script dir
 SCRIPT_DIR=$(
@@ -46,6 +47,11 @@ if [[ -e "$TARGET" ]]; then
     2)
       rm -f "$TARGET"
       echo "Removed smtty from $TARGET"
+      # Also remove smtty-update if it exists
+      if [[ -f "$UPDATER_TARGET" ]]; then
+        rm -f "$UPDATER_TARGET"
+        echo "Removed smtty-update from $UPDATER_TARGET"
+      fi
       # optional config removal
       if [[ -d "$HOME/.config/smtty" ]]; then
         read -rp "Remove config directory $HOME/.config/smtty? [y/N]: " c
@@ -67,6 +73,13 @@ else
   echo "Installed smtty to $TARGET"
 fi
 
+# Install smtty-update if available
+if [[ -f "$SCRIPT_DIR/smtty-update" ]]; then
+  cp "$SCRIPT_DIR/smtty-update" "$UPDATER_TARGET"
+  chmod +x "$UPDATER_TARGET"
+  echo "Installed smtty-update to $UPDATER_TARGET"
+fi
+
 # PATH hint
 case ":$PATH:" in
   *":$BINDIR:"*) ;;
@@ -80,3 +93,6 @@ esac
 
 echo
 echo "You can now run: smtty"
+if [[ -f "$UPDATER_TARGET" ]]; then
+  echo "To update smtty in the future, run: smtty-update"
+fi

--- a/smtty-update
+++ b/smtty-update
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# smtty-update - updater for smtty
+# Updates smtty from the official GitHub repository
+# Repository: https://github.com/dillacorn/smtty
+
+set -euo pipefail
+
+REPO_URL="https://github.com/dillacorn/smtty"
+REPO_DIR="$HOME/.cache/smtty-update"
+PREFIX=${PREFIX:-"$HOME/.local"}
+BINDIR="$PREFIX/bin"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+print_info() {
+    echo -e "${BLUE}[INFO]${NC} $*"
+}
+
+print_success() {
+    echo -e "${GREEN}[SUCCESS]${NC} $*"
+}
+
+print_warning() {
+    echo -e "${YELLOW}[WARNING]${NC} $*"
+}
+
+print_error() {
+    echo -e "${RED}[ERROR]${NC} $*"
+}
+
+# Check if git is installed
+if ! command -v git &>/dev/null; then
+    print_error "git is required but not installed."
+    echo "Please install git and try again."
+    exit 1
+fi
+
+# Get current version (if smtty exists)
+CURRENT_SMTTY="$BINDIR/smtty"
+if [[ -f "$CURRENT_SMTTY" ]]; then
+    print_info "Found smtty at: $CURRENT_SMTTY"
+else
+    print_warning "smtty not found at: $CURRENT_SMTTY"
+    print_info "This will perform a fresh installation."
+fi
+
+# Clone or update the repository
+if [[ -d "$REPO_DIR" ]]; then
+    print_info "Updating existing repository..."
+    cd "$REPO_DIR"
+
+    # Fetch latest changes
+    if ! git fetch origin main 2>/dev/null; then
+        print_error "Failed to fetch updates from repository."
+        print_info "Removing cached repository and retrying..."
+        cd "$HOME"
+        rm -rf "$REPO_DIR"
+        if ! git clone "$REPO_URL" "$REPO_DIR"; then
+            print_error "Failed to clone repository. Check your internet connection."
+            exit 1
+        fi
+        cd "$REPO_DIR"
+    else
+        # Reset to latest main only if fetch succeeded
+        git reset --hard origin/main
+        git clean -fd
+    fi
+else
+    print_info "Downloading smtty from GitHub..."
+    mkdir -p "$(dirname "$REPO_DIR")"
+    if ! git clone "$REPO_URL" "$REPO_DIR"; then
+        print_error "Failed to clone repository. Check your internet connection."
+        exit 1
+    fi
+    cd "$REPO_DIR"
+fi
+
+# Get the latest commit hash
+LATEST_COMMIT=$(git rev-parse --short HEAD)
+print_info "Latest version: $LATEST_COMMIT"
+
+# Check if we're already up to date
+if [[ -f "$CURRENT_SMTTY" ]]; then
+    # Try to find current version from smtty file
+    # (This assumes the commit hash might be embedded in the future,
+    #  for now we'll just proceed with the update)
+    print_info "Checking for updates..."
+fi
+
+# Show recent commits
+echo
+print_info "Recent changes:"
+git log -5 --oneline --decorate --color=always
+echo
+
+# Confirm update
+read -rp "Proceed with update/installation? [Y/n]: " confirm
+case "$confirm" in
+    [nN]*)
+        print_warning "Update cancelled."
+        exit 0
+        ;;
+esac
+
+# Create backup if smtty exists
+if [[ -f "$CURRENT_SMTTY" ]]; then
+    BACKUP="$CURRENT_SMTTY.backup.$(date +%Y%m%d-%H%M%S)"
+    print_info "Creating backup: $BACKUP"
+    cp "$CURRENT_SMTTY" "$BACKUP"
+fi
+
+# Install smtty and smtty-update
+mkdir -p "$BINDIR"
+
+if [[ -f "$REPO_DIR/smtty" ]]; then
+    cp "$REPO_DIR/smtty" "$BINDIR/smtty"
+    chmod +x "$BINDIR/smtty"
+    print_success "Updated smtty"
+else
+    print_error "smtty script not found in repository!"
+    exit 1
+fi
+
+# Install the updater itself
+UPDATER_INSTALLED=false
+if [[ -f "$REPO_DIR/smtty-update" ]]; then
+    cp "$REPO_DIR/smtty-update" "$BINDIR/smtty-update"
+    chmod +x "$BINDIR/smtty-update"
+    print_success "Updated smtty-update"
+    UPDATER_INSTALLED=true
+fi
+
+# Check PATH
+case ":$PATH:" in
+    *":$BINDIR:"*) ;;
+    *)
+        echo
+        print_warning "$BINDIR is not in your PATH."
+        echo "Add this to your shell config (example for bash):"
+        echo "  export PATH=\"$BINDIR:\$PATH\""
+        ;;
+esac
+
+echo
+print_success "Update complete! (commit: $LATEST_COMMIT)"
+echo
+echo "Installed files:"
+echo "  - smtty -> $BINDIR/smtty"
+if [[ "$UPDATER_INSTALLED" == "true" ]]; then
+    echo "  - smtty-update -> $BINDIR/smtty-update"
+fi
+echo
+
+if [[ -n "${BACKUP:-}" ]]; then
+    echo "Previous version backed up to: $BACKUP"
+    echo
+fi
+
+print_info "You can now run: smtty"


### PR DESCRIPTION
### Changes:

**New Files:**
- `smtty-update` - Standalone updater script that fetches and installs the latest version from GitHub

**Modified Files:**
- `install.sh` - Updated to install `smtty-update` alongside `smtty` and handle uninstallation

### Features:

- **One-command updates**: Users can run `smtty-update` to pull the latest version from https://github.com/dillacorn/smtty
- **Smart caching**: Clones the repository to `~/.cache/smtty-update` and reuses it for faster subsequent updates
- **Automatic backups**: Creates timestamped backups of the current version before updating
- **User confirmation**: Shows recent commits and asks for confirmation before proceeding
- **Self-updating**: The updater updates itself along with smtty
- **Robust error handling**: Handles network failures, corrupted cache, and missing dependencies gracefully
- **Colored output**: User-friendly colored status messages (INFO, SUCCESS, WARNING, ERROR)
- **PREFIX support**: Respects the same `PREFIX` environment variable as `install.sh`

### Usage:

After installing smtty with `./install.sh`, users can update at any time by running:
```bash
smtty-update